### PR TITLE
Add translation for "Procesando videos..."

### DIFF
--- a/resources/config/languages/translations.json
+++ b/resources/config/languages/translations.json
@@ -483,6 +483,14 @@
         "ru": "Отменить загрузку",
         "zh": "取消下载"
     },
+    "Procesando videos...": {
+        "es": "Procesando videos...",
+        "en": "Processing videos...",
+        "fr": "Traitement des vidéos...",
+        "ja": "ビデオを処理中..."
+        "ru": "Обработка видео...",
+        "zh": "处理视频中...",
+    }
     "Starting download from {media_url}": {
         "es": "Iniciando descarga desde {media_url}",
         "en": "Starting download from {media_url}",

--- a/resources/config/languages/translations.json
+++ b/resources/config/languages/translations.json
@@ -487,7 +487,7 @@
         "es": "Procesando videos...",
         "en": "Processing videos...",
         "fr": "Traitement des vidéos...",
-        "ja": "ビデオを処理中..."
+        "ja": "ビデオを処理中...",
         "ru": "Обработка видео...",
         "zh": "处理视频中...",
     },

--- a/resources/config/languages/translations.json
+++ b/resources/config/languages/translations.json
@@ -490,7 +490,7 @@
         "ja": "ビデオを処理中..."
         "ru": "Обработка видео...",
         "zh": "处理视频中...",
-    }
+    },
     "Starting download from {media_url}": {
         "es": "Iniciando descarga desde {media_url}",
         "en": "Starting download from {media_url}",


### PR DESCRIPTION
It was being piped into tr in line 286 of `ui.py`, but there was no translation for it in the file, so it always displayed "Procesando videos..." no matter the language.

https://github.com/Emy69/CoomerDL/blob/main/app/ui.py#L286
```python
self.processing_label.configure(text=self.tr("Procesando videos..."))
```